### PR TITLE
Remove one of the two light sources

### DIFF
--- a/include/LeMonADE-Viewer/LeMonADEOpenGL.h
+++ b/include/LeMonADE-Viewer/LeMonADEOpenGL.h
@@ -204,7 +204,7 @@ void LeMonADEOpenGL<IngredientsType>::generatePovRayScript(std::string croppedFi
 	afile << "sky_sphere{pigment{color rgb< " << ingredients.getBGcolor()[0] << ", " << ingredients.getBGcolor()[1] << ", " << ingredients.getBGcolor()[2] << "> }}" << std::endl;
 	afile << "" << std::endl;
 	afile << "// light source" << std::endl;
-	afile << "light_source{<1000.0, 1000.0, -200.0> color White}" << std::endl;
+	//afile << "light_source{<1000.0, 1000.0, -200.0> color White}" << std::endl;
 
 	afile << "light_source{< " << cam.getCamXPos() << " , " << -cam.getCamZPos() << " , " << -cam.getCamYPos() << " > color White"<< std::endl;
 	//afile << "fade_distance " << -(cam.getCamYPos()+0.5*boxY) << std::endl;


### PR DESCRIPTION
There is one fixed light source and one from the direction of the camera. Depending on the camera this leads to weird two reflections on each monomer:
![colored_000001-two-lights](https://user-images.githubusercontent.com/6842824/35107236-ba0bcbea-fc70-11e7-82b9-fdc2c1f84bd3.png)
Here is with only one source after this commit:
![colored_000001-one-light](https://user-images.githubusercontent.com/6842824/35107250-c0497b74-fc70-11e7-8d3c-03d213514355.png)
